### PR TITLE
Add track-email API endpoint

### DIFF
--- a/pages/api/track-email.ts
+++ b/pages/api/track-email.ts
@@ -1,0 +1,26 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.setHeader('Access-Control-Allow-Origin', '*')
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end()
+    return
+  }
+
+  if (req.method !== 'POST') {
+    res.status(405).json({ message: 'Method Not Allowed' })
+    return
+  }
+
+  const { email } = req.body as { email?: string }
+  if (!email) {
+    res.status(400).json({ message: 'Email is required' })
+    return
+  }
+
+  console.log('📧 Tracked email:', email)
+  res.status(200).json({ ok: true })
+}


### PR DESCRIPTION
## Summary
- implement `/api/track-email` endpoint

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684738fa12dc8325b18135572b21cafc