### PR TITLE
Implement stats API endpoint

### DIFF
--- a/pages/api/stats.ts
+++ b/pages/api/stats.ts
@@ -1,0 +1,40 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { Pool } from 'pg'
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+})
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'GET') {
+    res.status(405).end()
+    return
+  }
+
+  try {
+    const { rows } = await pool.query(
+      `
+      SELECT
+        utm_source,
+        utm_campaign,
+        COUNT(*) AS count,
+        SUM(amount) AS total_amount
+      FROM
+        "DataSlow payments"
+      WHERE
+        status = 'succeeded'
+      GROUP BY
+        utm_source, utm_campaign
+      ORDER BY
+        total_amount DESC;
+      `
+    )
+    res.status(200).json(rows)
+  } catch (err) {
+    console.error('❌ Stats error:', err)
+    res.status(500).json({ error: 'Internal server error' })
+  }
+}


### PR DESCRIPTION
## Summary
- add `/api/stats` to expose aggregated payment statistics

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b2f4602483258ae7a4ecd2104629