### PR TITLE
Add CORS headers to stats API

### DIFF
--- a/pages/api/stats.ts
+++ b/pages/api/stats.ts
@@ -9,6 +9,9 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
+  res.setHeader("Access-Control-Allow-Origin", "*")
+  res.setHeader("Access-Control-Allow-Methods", "GET")
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type")
   if (req.method !== 'GET') {
     res.status(405).end()
     return


### PR DESCRIPTION
## Summary
- allow CORS on `/api/stats` by setting the response headers

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847be51f5a883259ef2422e1c0d61bc