### PR TITLE
Add sanitized payment logging

### DIFF
--- a/pages/api/yookassa-webhook.ts
+++ b/pages/api/yookassa-webhook.ts
@@ -1,6 +1,15 @@
 import { Pool } from 'pg'
 import getRawBody from 'raw-body'
 
+function logPayment(prefix: string, body: any) {
+  const info = {
+    id: body?.object?.id,
+    status: body?.object?.status,
+    amount: body?.object?.amount?.value,
+  }
+  console.log(prefix, info)
+}
+
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
 })
@@ -16,11 +25,12 @@ export default async function handler(req, res) {
     return res.status(405).end()
   }
 
+  let body: any = null
   try {
     const raw = await getRawBody(req)
-    const body = JSON.parse(raw.toString())
+    body = JSON.parse(raw.toString())
 
-    console.log('📩 Webhook payload:', JSON.stringify(body, null, 2))
+    logPayment('📩 Webhook payload:', body)
 
     const { amount, status, metadata } = body.object || {}
     const { value, currency } = amount || {}
@@ -44,7 +54,7 @@ export default async function handler(req, res) {
     console.log('✅ Payment inserted')
     res.status(200).json({ ok: true })
   } catch (err) {
-    console.error('❌ Webhook error:', err)
+    logPayment('❌ Webhook error:', body)
     res.status(500).json({ error: 'Webhook failed' })
   }
 }


### PR DESCRIPTION
## Summary
- log high-level payment info via `logPayment`
- avoid logging sensitive card or email data in webhook handler

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848403c0f7c8325820bcf17bda0188e