### PR TITLE
Add validation for payment amount

### DIFF
--- a/pages/api/create-payment.ts
+++ b/pages/api/create-payment.ts
@@ -27,7 +27,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return
   }
 
-  const { amount } = req.body
+  const { amount } = req.body as { amount?: string }
+  if (typeof amount !== 'string' || !/^\d+(?:\.\d+)?$/.test(amount) || parseFloat(amount) <= 0) {
+    res.status(400).json({ message: 'Invalid amount' })
+    return
+  }
 
   const sanitizedHeaders = { ...req.headers }
   if ('authorization' in sanitizedHeaders) {


### PR DESCRIPTION
## Summary
- validate incoming `amount` in `create-payment` API

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684840434ddc8325928c44e6005f0dda