### PR TITLE
Fix track-email fetch url

### DIFF
--- a/public/analytics.js
+++ b/public/analytics.js
@@ -40,7 +40,7 @@
     };
     if (email) localStorage.setItem("email", email);
     try {
-      await fetch("https://dataslow-vercel.vercel.app/api/track-email", {
+      await fetch("/api/track-email", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload)


### PR DESCRIPTION
## Summary
- use relative path for `/api/track-email`

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848404d01c083258934ceacb7fbaefc