### PR TITLE
Fix bracket issue in webhook handler

### DIFF
--- a/pages/api/yookassa-webhook.ts
+++ b/pages/api/yookassa-webhook.ts
@@ -57,7 +57,7 @@ export default async function handler(req, res) {
     }
 
 
-    const body = JSON.parse(raw.toString())
+    body = JSON.parse(raw.toString())
 
 
     logPayment('📩 Webhook payload:', body)
@@ -90,8 +90,6 @@ export default async function handler(req, res) {
   }
   console.error('❌ Webhook error:', err)
   logPayment('❌ Webhook error:', body)
+  res.status(500).json({ error: 'Webhook failed' })
 }
-
-    res.status(500).json({ error: 'Webhook failed' })
-  }
 }


### PR DESCRIPTION
## Summary
- fix unbalanced closing braces in `yookassa-webhook.ts`
- assign webhook body to existing variable instead of redeclaration

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684845b3c5648325b4106504ace72a8c