### PR TITLE
Fix webhook verification

### DIFF
--- a/pages/api/yookassa-webhook.ts
+++ b/pages/api/yookassa-webhook.ts
@@ -15,7 +15,9 @@ const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
 })
 
-const verifySignature = process.env.NODE_ENV === 'production'
+// YooKassa signs webhooks even in the test environment, so we always verify
+// the signature.
+const verifySignature = true
 
 export const config = {
   api: {
@@ -30,6 +32,8 @@ export default async function handler(req, res) {
 
   let body: any = null
   try {
+
+    console.log('📬 Webhook headers:', req.headers)
 
     const raw = await getRawBody(req, { limit: '1mb' })
 


### PR DESCRIPTION
## Summary
- restore YooKassa webhook signature verification in all environments
- log incoming webhook headers for debugging

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486e7ef91c83258db186ac58c87e9d