### PR TITLE
Fix type definitions for ecdsa webhook

### DIFF
--- a/pages/api/ecdsa-webhook.ts
+++ b/pages/api/ecdsa-webhook.ts
@@ -1,5 +1,6 @@
 import getRawBody from 'raw-body'
 import crypto from 'crypto'
+import type { NextApiRequest, NextApiResponse } from 'next'
 
 export const config = {
   api: { bodyParser: false },
@@ -35,7 +36,10 @@ function verify(header: string | string[] | undefined): boolean {
   }
 }
 
-export default async function handler(req, res) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
   if (req.method !== 'POST') {
     return res.status(405).end()
   }


### PR DESCRIPTION
## Summary
- type the Next.js API handler for the ECDSA webhook

## Testing
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684891a9b8f8832580803bb0980c0bf1