### PR TITLE
Fix handler typing

### DIFF
--- a/pages/api/yookassa-webhook.ts
+++ b/pages/api/yookassa-webhook.ts
@@ -1,3 +1,4 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
 import { Pool } from 'pg'
 import getRawBody from 'raw-body'
 import crypto from 'crypto'
@@ -34,7 +35,10 @@ export const config = {
   },
 }
 
-export default async function handler(req, res) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
   if (req.method !== 'POST') {
     return res.status(405).end()
   }


### PR DESCRIPTION
## Summary
- add Next.js API types to the YooKassa webhook handler

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'next' or its type declarations, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6848939af4bc8325be24356e7a767bbb