### PR TITLE
Add raw body logging for YooKassa webhook

### DIFF
--- a/pages/api/yookassa-webhook.ts
+++ b/pages/api/yookassa-webhook.ts
@@ -59,6 +59,8 @@ export default async function handler(
   )
 
     const raw = await getRawBody(req, { limit: '1mb' })
+    const rawBody = raw.toString('utf-8')
+    console.log('📦 Webhook raw body:', rawBody)
 
     if (verifySignature) {
       const header = req.headers['signature'] || (req.headers as any)['Signature']
@@ -107,7 +109,7 @@ export default async function handler(
     }
 
 
-    body = JSON.parse(raw.toString())
+    body = JSON.parse(rawBody)
 
 
     logPayment('📩 Webhook payload:', body)


### PR DESCRIPTION
## Summary
- log the raw webhook body string in `/api/yookassa-webhook`

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a7694e8083259a2d063fe3c86e23