### PR TITLE
Fix stats parameter validation

### DIFF
--- a/pages/api/stats.ts
+++ b/pages/api/stats.ts
@@ -15,7 +15,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return
   }
 
-  const { daily, hourly, date_filter } = req.query
+  let { daily, hourly, date_filter } = req.query
+  const dailyFlag = daily === 'true'
+  const hourlyFlag = hourly === 'true'
+
+  if (!dailyFlag && !hourlyFlag) {
+    if (daily === undefined && hourly === undefined) {
+      daily = 'true'
+    } else {
+      res.status(400).json({ error: 'Invalid parameters' })
+      return
+    }
+  }
+
   const filter = String(date_filter || '').toLowerCase()
 
   let dateWhere = `TRUE`

--- a/scripts/manual_check_stats.js
+++ b/scripts/manual_check_stats.js
@@ -1,0 +1,37 @@
+const { execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const outDir = path.join(__dirname, '.tmp');
+fs.rmSync(outDir, { recursive: true, force: true });
+try {
+  execSync(`tsc ${path.join('pages','api','stats.ts')} --outDir ${outDir} --esModuleInterop --skipLibCheck --lib ES2019,DOM --moduleResolution node`, { stdio: 'ignore' });
+} catch { /* compilation errors are ignored */ }
+const Module = require('module');
+const originalRequire = Module.prototype.require;
+Module.prototype.require = function(request){
+  if (request === 'pg') {
+    return { Pool: class { query() { return Promise.resolve({ rows: [] }); } } };
+  }
+  return originalRequire.call(this, request);
+};
+const handler = require(path.join(outDir, 'stats.js')).default;
+async function run(){
+  const cases=[
+    { query:{}, desc:'no parameters'},
+    { query:{hourly:'true'}, desc:'hourly=true'},
+    { query:{daily:'false'}, desc:'invalid daily'},
+    { query:{daily:'true'}, desc:'daily=true'}
+  ];
+  for(const c of cases){
+    const req={method:'GET', query:c.query};
+    const res={headers:{}, statusCode:0, body:null,
+      setHeader(k,v){this.headers[k]=v;},
+      status(code){this.statusCode=code; return this;},
+      json(b){this.body=b; return this;},
+      end(){}}
+    await handler(req,res);
+    console.log(c.desc, res.statusCode, res.body);
+  }
+  fs.rmSync(outDir, { recursive: true, force: true });
+}
+run();


### PR DESCRIPTION
## Summary
- validate `hourly`/`daily` query params in `/api/stats`
- add a manual check script for the stats endpoint

## Testing
- `node scripts/manual_check_stats.js`


------
https://chatgpt.com/codex/tasks/task_e_684ec5c5c02c83259e1ede61a5ec8920