### PR TITLE
Add visits count to stats

### DIFF
--- a/pages/api/stats.ts
+++ b/pages/api/stats.ts
@@ -110,11 +110,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const { rows } = await pool.query(query)
 
+    const visits_count = rows.length
+
     const visitsCountCheckQuery = `SELECT COUNT(*) AS visits_count_check FROM visits WHERE ${visitsDateWhere}`
     const { rows: visitsCheckRows } = await pool.query(visitsCountCheckQuery)
     const visits_count_check = visitsCheckRows[0]?.visits_count_check || 0
 
-    res.status(200).json({ data: rows, visits_count_check })
+    res.status(200).json({ data: rows, visits_count, visits_count_check })
   } catch (err) {
     console.error('❌ Stats error:', err)
     res.status(500).json({ error: 'Internal server error' })


### PR DESCRIPTION
## Summary
- calculate `visits_count` in `stats` handler
- include `visits_count` in the JSON response

## Testing
- `node scripts/manual_check_stats.js`

------
https://chatgpt.com/codex/tasks/task_e_684f0142727c83259ab855e4c4cc9fbf